### PR TITLE
Enable devtools metric updates

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,5 +1,6 @@
 (function() {
   if (document.getElementById('ofio-overlay')) return; // Don't inject twice
+  let overlayEl;
 
   // Fetch the HTML
   fetch(chrome.runtime.getURL('overlay.html'))
@@ -7,6 +8,7 @@
     .then(html => {
       const overlay = document.createElement('div');
       overlay.id = 'ofio-overlay';
+      overlayEl = overlay;
       overlay.style = `
         position: fixed;
         left: 40%;
@@ -44,7 +46,16 @@
         });
       });
 
-      
+
     });
+
+  chrome.runtime.onMessage.addListener((msg) => {
+    if (msg.type === 'metrics-update' && overlayEl) {
+      const popSpan = overlayEl.querySelector('#overlay-pop');
+      const goldSpan = overlayEl.querySelector('#overlay-gold');
+      if (popSpan) popSpan.textContent = msg.pop;
+      if (goldSpan) goldSpan.textContent = msg.gold;
+    }
+  });
 
 })();

--- a/devtools.js
+++ b/devtools.js
@@ -1,4 +1,5 @@
 let retrievalInterval;
+let metricsInterval;
 let retrieving = false;
 
 function tryGetGame() {
@@ -16,6 +17,7 @@ function tryGetGame() {
     if (!isException && result) {
       clearInterval(retrievalInterval);
       retrieving = false;
+      startMetrics();
     }
   });
 }
@@ -25,6 +27,34 @@ function startRetrieval() {
   retrieving = true;
   tryGetGame();
   retrievalInterval = setInterval(tryGetGame, 1000);
+}
+
+function sendMetrics() {
+  const code = `(() => {
+    if (window.game && window.game._myPlayer && window.game._myPlayer.data) {
+      return {
+        pop: window.game._myPlayer.data.population,
+        gold: window.game._myPlayer.data.gold
+      };
+    }
+    return null;
+  })()`;
+
+  chrome.devtools.inspectedWindow.eval(code, (result, isException) => {
+    if (!isException && result) {
+      chrome.runtime.sendMessage({
+        type: 'metrics-update',
+        pop: result.pop,
+        gold: result.gold
+      });
+    }
+  });
+}
+
+function startMetrics() {
+  if (metricsInterval) return;
+  sendMetrics();
+  metricsInterval = setInterval(sendMetrics, 200);
 }
 
 chrome.runtime.onMessage.addListener((msg) => {


### PR DESCRIPTION
## Summary
- retrieve population and gold from `game` via devtools
- stream metrics from devtools to the content script
- update overlay metrics text when new data arrives

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6853680994a88331925694a6a2311b20