### PR TITLE
Relay metrics via background service worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenFrontIO Overlay Chrome Extension
 
-This extension injects a small overlay into the OpenFrontIO game page. The overlay currently displays placeholder metrics and a button to retrieve game state. Future versions will hook this up to the actual game state.
+This extension injects a small overlay into the OpenFrontIO game page. The overlay currently displays placeholder metrics and a button to retrieve game state. Metrics are sent from the DevTools page through a background service worker before reaching the content script. Future versions will hook this up to the actual game state.
 
 ## Development
 

--- a/background.js
+++ b/background.js
@@ -1,0 +1,5 @@
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'metrics-update' && typeof msg.tabId === 'number') {
+    chrome.tabs.sendMessage(msg.tabId, msg);
+  }
+});

--- a/devtools.js
+++ b/devtools.js
@@ -45,7 +45,8 @@ function sendMetrics() {
       chrome.runtime.sendMessage({
         type: 'metrics-update',
         pop: result.pop,
-        gold: result.gold
+        gold: result.gold,
+        tabId: chrome.devtools.inspectedWindow.tabId
       });
     }
   });

--- a/manifest.json
+++ b/manifest.json
@@ -19,5 +19,8 @@
       "matches": ["<all_urls>"]
     }
   ],
+  "background": {
+    "service_worker": "background.js"
+  },
   "devtools_page": "devtools.html"
 }


### PR DESCRIPTION
## Summary
- implement a background service worker to forward metrics messages
- include tabId when sending metrics from the devtools page
- register the service worker in the extension manifest
- note the new background relay behavior in the README